### PR TITLE
Remove need for `mergeState`

### DIFF
--- a/src/App/adapter/init.js
+++ b/src/App/adapter/init.js
@@ -19,11 +19,22 @@ const makeLabelCandidates = (obj) => {
   return { ...obj, label }
 }
 
-function init(filterables) {
-  const list = Object.entries(filterables).flatMap(([k, v]) =>
-    v.flatMap((i) => ({ ...i, group: k })),
-  )
-  return list.map(makeLabelCandidates).reduce(uniqueLabelReducer, [])
+function init(groupedFilterables) {
+  const filterablesArr = Object.entries(groupedFilterables)
+    .flatMap(([group, arr]) => arr.map((f) => ({ ...f, group }))) // flatten filterables, while keeping a reference to their groups
+    .map(makeLabelCandidates) // generate missing labels
+    .reduce(uniqueLabelReducer, []) // make sure labels are unique
+    // add specific operators
+    .map((obj) =>
+      obj.range
+        ? { ...obj, operator: 'between' }
+        : ['title', 'sample_chemical_formula'].includes(obj.name)
+        ? { ...obj, operator: 'like' }
+        : obj,
+    )
+
+  // Store filterables by label so as to find them easily in `translate`
+  return Object.fromEntries(filterablesArr.map((f) => [f.label, f]))
 }
 
 export default init

--- a/src/App/adapter/lib/state.js
+++ b/src/App/adapter/lib/state.js
@@ -2,7 +2,6 @@ import OPERATORS from '../operators.json'
 import MAP from '../targets.json'
 
 const FALLBACK_GROUP_OPERATOR = 'and'
-const LABEL_FOR_CONFIG = 'c'
 
 const resolveOperator = (label) => OPERATORS[label] || FALLBACK_GROUP_OPERATOR
 
@@ -62,28 +61,4 @@ export function parseState(state, config) {
   const where = groups.find((obj) => obj.label === endpoint)
 
   return [include, where]
-}
-
-const squash = (list) => {
-  const pairs = list.flatMap((obj) => Object.entries(obj))
-  return pairs.reduce((acc, scope) => ({ ...acc, [scope[0]]: scope[1] }), {})
-}
-
-const groupByLabel = (list) =>
-  list.reduce(
-    (acc, scope) => ({
-      ...acc,
-      [scope.label]: [...(acc[scope.label] || []), scope],
-    }),
-    {},
-  )
-
-export function mergeState(inits, diffs) {
-  const useful = diffs.reduce(
-    (acc, scope) => [...acc, scope.label, scope.group],
-    [LABEL_FOR_CONFIG],
-  )
-  const usefulInits = inits.filter(({ label }) => useful.includes(label))
-  const byLabel = groupByLabel([...usefulInits, ...diffs])
-  return Object.entries(byLabel).flatMap(([, a]) => squash(a))
 }

--- a/src/App/adapter/translate.js
+++ b/src/App/adapter/translate.js
@@ -1,19 +1,21 @@
 import { createInclude, createWhere } from './lib/create'
 import { stripEmptyKeys } from './lib/helpers'
-import { createPagination, mergeState, parseState } from './lib/state'
+import { createPagination, parseState } from './lib/state'
 
 const DEFAULT_CONFIG = {
   endpoint: 'documents',
+  filterables: [],
   include: [],
   pageSize: 5, // `false` to disable limit/pagination
   page: 1,
   order: undefined, // e.g.`['foo ASC', 'bar DESC']`
 }
 
-function translate(diffState, initialState = [], queryConfig = {}) {
+function translate(filters, queryConfig = {}) {
   const config = { ...DEFAULT_CONFIG, ...queryConfig }
+  const { filterables, order } = config
 
-  const state = mergeState(initialState, diffState)
+  const state = filters.map((f) => ({ ...filterables[f.label], ...f }))
   const [toInclude, toWhere] = parseState(state, config)
 
   const include = createInclude(toInclude)
@@ -23,7 +25,7 @@ function translate(diffState, initialState = [], queryConfig = {}) {
   return stripEmptyKeys({
     include,
     where,
-    order: config.order,
+    order,
     ...pagination,
   })
 }

--- a/src/App/adapter/translate.test.js
+++ b/src/App/adapter/translate.test.js
@@ -1,26 +1,23 @@
-import { initialFilters } from '../../filters'
+import { filterables } from '../../filters'
 import translate from './translate'
 
 test('no filter and default config', () => {
-  const query = translate([], initialFilters)
+  const query = translate([])
   expect(query).toEqual({ limit: 5 })
 })
 
 test('no pagination', () => {
-  const query = translate([], initialFilters, { pageSize: false })
+  const query = translate([], { pageSize: false })
   expect(query).toEqual({})
 })
 
 test('custom pagination', () => {
-  const query = translate([], initialFilters, { pageSize: 10, page: 2 })
+  const query = translate([], { pageSize: 10, page: 2 })
   expect(query).toEqual({ limit: 10, skip: 10 })
 })
 
 test('custom ordering', () => {
-  const query = translate([], initialFilters, {
-    order: ['foo ASC', 'bar DESC'],
-  })
-
+  const query = translate([], { order: ['foo ASC', 'bar DESC'] })
   expect(query).toEqual({ order: ['foo ASC', 'bar DESC'], limit: 5 })
 })
 
@@ -32,8 +29,10 @@ test('single root filter and custom include', () => {
         value: 'proposal',
       },
     ],
-    initialFilters,
-    { include: ['datasets', 'affiliation', 'person'] },
+    {
+      filterables,
+      include: ['datasets', 'affiliation', 'person'],
+    },
   )
 
   expect(query).toEqual({
@@ -63,8 +62,10 @@ test('multiple filters and custom include', () => {
         value: ['0', '7300'],
       },
     ],
-    initialFilters,
-    { include: ['datasets', 'affiliation', 'person'] },
+    {
+      filterables,
+      include: ['datasets', 'affiliation', 'person'],
+    },
   )
 
   expect(query).toEqual({

--- a/src/Document/DocumentPage.js
+++ b/src/Document/DocumentPage.js
@@ -13,7 +13,6 @@ function DocumentPage() {
       ['datasets', 'instrument'],
       ['members', 'person'],
     ],
-    limit: false,
   })
 
   const { documentId } = useParams()

--- a/src/Explore/DocumentList.js
+++ b/src/Explore/DocumentList.js
@@ -4,17 +4,17 @@ import { useSWRInfinite } from 'swr'
 
 import Boundary from '../App/Boundary'
 import Spinner from '../App/Spinner'
+import translate from '../App/adapter/translate'
 import { useAppStore } from '../App/stores'
 import { Flex, Card, Text, Heading, Button, Box } from '../Primitives'
-import { useFilters, initialFilters } from '../filters'
-import translate from '../App/adapter/translate'
+import { useFilters, filterables } from '../filters'
 import DocumentItem from './DocumentItem'
 
 const PAGE_SIZE = 5
 const QUERY_CONFIG = {
+  filterables,
   include: ['datasets', 'affiliation', 'person'],
   pageSize: PAGE_SIZE,
-  label: 'c',
 }
 
 function DocumentList() {
@@ -25,10 +25,7 @@ function DocumentList() {
   const filters = useFilters()
 
   const { data, size, setSize, error } = useSWRInfinite((page) => {
-    const filter = translate(
-      [...filters, { ...QUERY_CONFIG, page: page + 1 }],
-      initialFilters,
-    )
+    const filter = translate(filters, { ...QUERY_CONFIG, page: page + 1 })
 
     const newQuery = encodeURIComponent(JSON.stringify(filter))
     if (newQuery !== query) {

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -3,11 +3,12 @@ import shallow from 'zustand/shallow'
 
 import { useAppStore } from '../App/stores'
 import { Card, Flex, Text, Button } from '../Primitives'
-import { initialFilters } from '../filters'
+import { filterables } from '../filters'
 import FilterGroup from './FilterGroup'
 
 const ORDER = ['title', 'type', 'keywords']
 const sortFilters = (a, b) => ORDER.indexOf(a?.name) - ORDER.indexOf(b?.name)
+const filterablesArr = Object.values(filterables)
 
 function Search() {
   const [loadOnScroll, toggleLoadOnScroll] = useAppStore(
@@ -15,11 +16,11 @@ function Search() {
     shallow,
   )
 
-  const rootFilters = initialFilters.filter((obj) => obj.group === 'documents')
-  const parameterFilters = initialFilters.filter(
+  const rootFilters = filterablesArr.filter((obj) => obj.group === 'documents')
+  const parameterFilters = filterablesArr.filter(
     (obj) => obj.group === 'parameters',
   )
-  const techniques = initialFilters.filter((obj) => obj.group === 'techniques')
+  const techniques = filterablesArr.filter((obj) => obj.group === 'techniques')
 
   return (
     <Flex column gap={[3, 3, 3, 4]}>

--- a/src/filters.js
+++ b/src/filters.js
@@ -1,16 +1,8 @@
 import init from './App/adapter/init'
-import filterables from './filterables.json'
+import groupedFilterables from './filterables.json'
 import { useQuery, JOIN_CHAR } from './router-utils'
 
-const base = init(filterables).map((obj) =>
-  obj.range
-    ? { ...obj, operator: 'between', value: obj.range }
-    : ['title', 'sample_chemical_formula'].includes(obj.name)
-    ? { ...obj, value: '', operator: 'like' }
-    : obj,
-)
-
-export const initialFilters = base
+export const filterables = init(groupedFilterables)
 
 const zip = (pair) => {
   const [k, v] = pair


### PR DESCRIPTION
As per their name, `filterables` represent things that can be filtered. They are _static_ definition objects, so by definition I don't see them as a "state" but as a configuration. This is the premise for this PR.

Currently `mergeState` takes two arrays: the `fitlerables`  and the `filters` and returns a single array that has the same length as `filters` where the objects contain the filter values from `filters` (`value`) and the other static properties from `filterables` (`operator`, `name`, etc.)

This PR removes the `mergeState` function completely and replaces it with a single line that maps through the `filters` and, for each filter object, merges it with its corresponding filterable definition object. I managed to get this opertion down to one line by simply storing the filterables by label - i.e. `{ 'do-type': { label: 'do-type', name: 'type', ... }`.