### PR TITLE
Revert recent changes to translate() & co., refactor

### DIFF
--- a/src/App/adapter/translate.test.js
+++ b/src/App/adapter/translate.test.js
@@ -1,40 +1,48 @@
-import { initialFilters } from '../../filters'
-import translate from './translate'
+import { template } from '../../filters'
+import { LABEL_FOR_CONFIG } from './lib/state'
+import applyTemplate from './translate'
+
+const translate = applyTemplate(template)
+
+const label = LABEL_FOR_CONFIG
 
 test('no filter and default config', () => {
-  const query = translate([], initialFilters)
+  const query = translate([])
   expect(query).toEqual({ limit: 5 })
 })
 
 test('no pagination', () => {
-  const query = translate([], initialFilters, { pageSize: false })
+  const query = translate([{ label, pageSize: false }])
   expect(query).toEqual({})
 })
 
 test('custom pagination', () => {
-  const query = translate([], initialFilters, { pageSize: 10, page: 2 })
+  const query = translate([{ label, pageSize: 10, page: 2 }])
   expect(query).toEqual({ limit: 10, skip: 10 })
 })
 
 test('custom ordering', () => {
-  const query = translate([], initialFilters, {
-    order: ['foo ASC', 'bar DESC'],
-  })
+  const query = translate(
+    [
+      {
+        label,
+        order: ['foo ASC', 'bar DESC'],
+      },
+    ],
+    template,
+  )
 
   expect(query).toEqual({ order: ['foo ASC', 'bar DESC'], limit: 5 })
 })
 
 test('single root filter and custom include', () => {
-  const query = translate(
-    [
-      {
-        label: 'do-type',
-        value: 'proposal',
-      },
-    ],
-    initialFilters,
-    { include: ['datasets', 'affiliation', 'person'] },
-  )
+  const query = translate([
+    { label, include: ['datasets', 'affiliation', 'person'] },
+    {
+      label: 'do-type',
+      value: 'proposal',
+    },
+  ])
 
   expect(query).toEqual({
     include: [
@@ -52,20 +60,17 @@ test('single root filter and custom include', () => {
 })
 
 test('multiple filters and custom include', () => {
-  const query = translate(
-    [
-      {
-        label: 'do-type',
-        value: 'experiment',
-      },
-      {
-        label: 'pa-sample_temperature',
-        value: ['0', '7300'],
-      },
-    ],
-    initialFilters,
-    { include: ['datasets', 'affiliation', 'person'] },
-  )
+  const query = translate([
+    { label, include: ['datasets', 'affiliation', 'person'] },
+    {
+      label: 'do-type',
+      value: 'experiment',
+    },
+    {
+      label: 'pa-sample_temperature',
+      value: ['0', '7300'],
+    },
+  ])
 
   expect(query).toEqual({
     include: [

--- a/src/Explore/DocumentList.js
+++ b/src/Explore/DocumentList.js
@@ -6,8 +6,7 @@ import Boundary from '../App/Boundary'
 import Spinner from '../App/Spinner'
 import { useAppStore } from '../App/stores'
 import { Flex, Card, Text, Heading, Button, Box } from '../Primitives'
-import { useFilters, initialFilters } from '../filters'
-import translate from '../App/adapter/translate'
+import { useFilters, translate } from '../filters'
 import DocumentItem from './DocumentItem'
 
 const PAGE_SIZE = 5
@@ -27,7 +26,7 @@ function DocumentList() {
   const { data, size, setSize, error } = useSWRInfinite((page) => {
     const filter = translate(
       [...filters, { ...QUERY_CONFIG, page: page + 1 }],
-      initialFilters,
+      'documents',
     )
 
     const newQuery = encodeURIComponent(JSON.stringify(filter))

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -3,7 +3,7 @@ import shallow from 'zustand/shallow'
 
 import { useAppStore } from '../App/stores'
 import { Card, Flex, Text, Button } from '../Primitives'
-import { initialFilters } from '../filters'
+import { template } from '../filters'
 import FilterGroup from './FilterGroup'
 
 const ORDER = ['title', 'type', 'keywords']
@@ -15,11 +15,9 @@ function Search() {
     shallow,
   )
 
-  const rootFilters = initialFilters.filter((obj) => obj.group === 'documents')
-  const parameterFilters = initialFilters.filter(
-    (obj) => obj.group === 'parameters',
-  )
-  const techniques = initialFilters.filter((obj) => obj.group === 'techniques')
+  const rootFilters = template.filter((obj) => obj.group === 'documents')
+  const parameterFilters = template.filter((obj) => obj.group === 'parameters')
+  const techniques = template.filter((obj) => obj.group === 'techniques')
 
   return (
     <Flex column gap={[3, 3, 3, 4]}>

--- a/src/filters.js
+++ b/src/filters.js
@@ -1,16 +1,28 @@
 import init from './App/adapter/init'
+import applyTemplate from './App/adapter/translate'
 import filterables from './filterables.json'
 import { useQuery, JOIN_CHAR } from './router-utils'
 
-const base = init(filterables).map((obj) =>
-  obj.range
-    ? { ...obj, operator: 'between', value: obj.range }
-    : ['title', 'sample_chemical_formula'].includes(obj.name)
-    ? { ...obj, value: '', operator: 'like' }
-    : obj,
-)
+const base = init(filterables)
 
-export const initialFilters = base
+const assertReasonableDefaults = (list) =>
+  list.map((obj) => {
+    const { range, options } = obj
+
+    if (range) {
+      return { ...obj, operator: 'between' }
+    }
+
+    if (options) {
+      return obj
+    }
+
+    return { ...obj, operator: 'ilike' }
+  })
+
+export const template = assertReasonableDefaults(base)
+
+export const translate = applyTemplate(template)
 
 const zip = (pair) => {
   const [k, v] = pair


### PR DESCRIPTION
Several variables were renamed so we don't deal with different flavours of state.

_merge()_ allows all elements forming the query to be incrementaly declared using stubs leveraging the following pattern:
`[...default, ...URIDependent, ...forced]`.
Also `?filter=value&filter~key=value` and `?filter=value&filter=something` merge properly.

Bringing back "config as a filter" approach to allow:
`?c~order=foo%20ASC~bar%20DESC`

Making endpoint a parameter again