### PR TITLE
Remove filter groups

### DIFF
--- a/src/Search/Autocomplete.js
+++ b/src/Search/Autocomplete.js
@@ -27,7 +27,7 @@ function Autocomplete(props) {
             <AsynAutocomplete
               id={obj.id}
               url={obj.optionsUrl}
-              emptyOption={`Select a ${obj.id}...`}
+              emptyOption={`Select a ${obj.display.toLowerCase()}...`}
             />
           </Suspense>
           <Button

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -13,9 +13,10 @@ function Search() {
     <Flex column gap={[3, 3, 3, 4]}>
       <Card>
         <Flex column gap={[3, 2, 3, 4]}>
-          <FilterGroup name="Search" filters={rootFilters} />
-          <FilterGroup name="Dataset" filters={techniqueFilters} />
-          <FilterGroup name="Parameter" filters={parameterFilters} />
+          <FilterGroup
+            name="Filter"
+            filters={[...rootFilters, ...techniqueFilters, ...parameterFilters]}
+          />
         </Flex>
       </Card>
     </Flex>

--- a/src/Search/TextInput.js
+++ b/src/Search/TextInput.js
@@ -24,6 +24,7 @@ function TextInput(props) {
       <Flex>
         <Input
           px={2}
+          fontSize={0}
           value={inputValue}
           onChange={(evt) => {
             const { value } = evt.target

--- a/src/theme.js
+++ b/src/theme.js
@@ -133,6 +133,7 @@ export function useTheme() {
         borderColor: 'secondary',
         textOverflow: 'ellipsis',
         overflow: 'hidden',
+        fontSize: 0,
         pr: '24px',
         option: {
           color: 'black',


### PR DESCRIPTION
I'm not sure the groups are relevant any more. This just puts all the filters under a single group labelled "FILTER":

![image](https://user-images.githubusercontent.com/2936402/161767043-b5c0c804-f0bb-47e9-83be-234e0de1c5df.png)

Let me know what you think.
